### PR TITLE
Use environment variable to set virtual path prefix in container

### DIFF
--- a/webapp/src/main/docker/scan_directory.py
+++ b/webapp/src/main/docker/scan_directory.py
@@ -41,7 +41,7 @@ def scan_directory(real_directory, virtual_directory, output_file):
                 # Get real and virtual paths to this file
                 real_absolute_path = real_filename.absolute()
                 relative_path = real_absolute_path.relative_to(real_directory)
-                virtual_absolute_path = (Path(virtual_directory) / relative_path).relative_to("/")
+                virtual_absolute_path = (Path(virtual_directory) / relative_path)
 
                 # Get size, last modification time and type
                 st = os.stat(real_absolute_path)
@@ -50,7 +50,7 @@ def scan_directory(real_directory, virtual_directory, output_file):
                 mtype = media_type(real_absolute_path)
 
                 # Write out the config line for this file
-                out.write(f"{virtual_absolute_path}, {real_absolute_path}, {int(size)}, {int(modtime)}, {mtype}\n")
+                out.write(f"{str(virtual_absolute_path).lstrip('/')}, {real_absolute_path}, {int(size)}, {int(modtime)}, {mtype}\n")
 
 
 if __name__ == "__main__":

--- a/webapp/src/main/docker/startup.sh
+++ b/webapp/src/main/docker/startup.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -e
 
+# Check if we have an env var with a virtual directory prefix
+if [[ -z "${HDFSTREAM_PREFIX}" ]]; then
+    # Default if not set
+    prefix="Data"
+else
+    prefix="${HDFSTREAM_PREFIX}"
+fi
+
 # Generate the config file
-python3 /opt/hdfstream/scan_directory.py /opt/hdfstream/data/ /Data /opt/hdfstream/config.csv
+python3 /opt/hdfstream/scan_directory.py /opt/hdfstream/data/ "${prefix}" /opt/hdfstream/config.csv
 
 # Start the service
 cd /usr/local/tomcat/bin/ && ./catalina.sh run


### PR DESCRIPTION
This should make it easier to make paths match between local and remote tests.