### PR TITLE
Limit to Tomcat<10 and Junit<6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/webapp"
     ignore:
       - dependency-name: "uk.ac.dur.cosma:libhdfstream"
+      - dependency-name: "org.apache.tomcat:*"
+        versions: [">=10.0.0"]
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [">=6.0.0"]
+
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Updates the dependabot config to reflect that we don't support Tomcat 10+ or Junit 6+ yet.