### PR TITLE
Use BOM to import junit

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -7,27 +7,38 @@
   <version>1.0-SNAPSHOT</version>
   <name>HDFStream webapp</name>
   <url>https://github.com/jchelly/hdfstream</url>
+
+  <!-- Junit components need to be updated together -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+	<groupId>org.junit</groupId>
+	<artifactId>junit-bom</artifactId>
+	<version>5.13.3</version>
+	<type>pom</type>
+	<scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <!-- Junit for unit tests -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.13.3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.13.3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.13.3</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This is to make sure dependabot updates Junit's various components in step.