### PR TITLE
Remove unused dependabot ignore entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,8 @@ updates:
     directory: "/webapp"
     ignore:
       - dependency-name: "uk.ac.dur.cosma:libhdfstream"
-      - dependency-name: "org.apache.tomcat:*"
-        versions: [">=10.0.0"]
       - dependency-name: "org.apache.tomcat.embed:*"
         versions: [">=10.0.0"]
-      - dependency-name: "org.junit.jupiter:*"
-        versions: [">=6.0.0"]
 
     schedule:
       interval: "daily"


### PR DESCRIPTION
Tomcat and Junit versions don't need to be restricted. The servlet API in Tomcat 10+ uses different names (javax->jakarta) but dependabot doesn't change package names. The embedded Tomcat used for testing does need to be restricted.