### PR TITLE
Allow updating the virtual directory configuration without restarting

### DIFF
--- a/webapp/CMakeLists.txt
+++ b/webapp/CMakeLists.txt
@@ -38,6 +38,7 @@ set(WEBAPP_SOURCES
   ./src/test/java/NDArray.java
   ./src/test/java/PermissionsUnitTest.java
   ./src/test/java/TestDataset.java
+  ./src/test/java/TestReload.java
   ./src/test/java/TestDimensionInfo.java
   ./src/test/java/TestDirectoryEntry.java
   ./src/test/java/TestFileDownload.java

--- a/webapp/CMakeLists.txt
+++ b/webapp/CMakeLists.txt
@@ -16,6 +16,9 @@ set(WEBAPP_SOURCES
   ./src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
   ./src/main/java/uk/ac/dur/cosma/hdfstream/StringSanitizer.java
   ./src/main/java/uk/ac/dur/cosma/hdfstream/TarFileServlet.java
+  ./src/main/java/uk/ac/dur/cosma/hdfstream/ConfigManager.java
+  ./src/main/java/uk/ac/dur/cosma/hdfstream/InternalConfigManager.java
+  ./src/main/java/uk/ac/dur/cosma/hdfstream/ExternalConfigManager.java
   ./src/main/webapp/RefL0012N0188_stars.png
   ./src/main/webapp/WEB-INF/error.jsp
   ./src/main/webapp/WEB-INF/status.jsp

--- a/webapp/src/main/docker/web.xml
+++ b/webapp/src/main/docker/web.xml
@@ -8,6 +8,28 @@
     <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 
+  <!-- Limit access to the server status page to localhost -->
+  <filter>
+    <filter-name>Remote Address Filter</filter-name>
+    <filter-class>org.apache.catalina.filters.RemoteAddrFilter</filter-class>
+    <init-param>
+      <param-name>allow</param-name>
+      <param-value>127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1</param-value>
+    </init-param>
+    <init-param>
+      <param-name>denyStatus</param-name>
+      <param-value>403</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>Remote Address Filter</filter-name>
+    <url-pattern>/status</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>Remote Address Filter</filter-name>
+    <url-pattern>/status/*</url-pattern>
+  </filter-mapping>
+
   <!-- Page returned in case of an error -->
   <error-page>
     <location>/WEB-INF/error.jsp</location>

--- a/webapp/src/main/example/web.xml
+++ b/webapp/src/main/example/web.xml
@@ -8,6 +8,28 @@
     <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 
+  <!-- Limit access to the server status page to localhost -->
+  <filter>
+    <filter-name>Remote Address Filter</filter-name>
+    <filter-class>org.apache.catalina.filters.RemoteAddrFilter</filter-class>
+    <init-param>
+      <param-name>allow</param-name>
+      <param-value>127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1</param-value>
+    </init-param>
+    <init-param>
+      <param-name>denyStatus</param-name>
+      <param-value>403</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>Remote Address Filter</filter-name>
+    <url-pattern>/status</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>Remote Address Filter</filter-name>
+    <url-pattern>/status/*</url-pattern>
+  </filter-mapping>
+
   <!-- Page returned in case of an error -->
   <error-page>
     <location>/WEB-INF/error.jsp</location>

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ConfigManager.java
@@ -1,0 +1,14 @@
+package uk.ac.dur.cosma.hdfstream;
+
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
+
+
+public abstract class ConfigManager {
+
+    /* Initialize the configuration */
+    public ConfigManager() {}
+
+    /* Get the current virtual directory root */
+    public abstract VirtualDirectory getRoot();
+}

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ConfigManager.java
@@ -9,6 +9,9 @@ public abstract class ConfigManager {
     /* Initialize the configuration */
     public ConfigManager() {}
 
+    /* Reload the configuration, if possible */
+    public abstract void reload() throws VirtualDirectoryException;
+
     /* Get the current virtual directory root */
     public abstract VirtualDirectory getRoot();
 }

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ExternalConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ExternalConfigManager.java
@@ -1,0 +1,53 @@
+package uk.ac.dur.cosma.hdfstream;
+
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.util.zip.GZIPInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
+
+
+public class ExternalConfigManager extends ConfigManager {
+
+    private String[] directory_configs = null;
+    private volatile VirtualDirectory root = null;
+
+    /* Initialize the configuration. This implementation reads
+     * external files (i.e. not in the .war) */
+    public ExternalConfigManager(String[] directory_configs) throws VirtualDirectoryException {
+        super();
+        this.directory_configs = directory_configs;
+        load();
+    }
+
+    private void load() throws VirtualDirectoryException {
+        VirtualDirectory vdir = new VirtualDirectory();
+        for(String directory_config : directory_configs) {
+            if(directory_config.endsWith(".gz")) {
+                /* Assume config file is gzipped if it has a .gz extension */
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(directory_config)))))) {
+                    vdir.addFromReader(reader);
+                } catch (Exception e) {
+                    throw new VirtualDirectoryException("Failed to read gzipped virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                }
+            } else {
+                /* Uncompressed config file */
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(directory_config))))) {
+                    vdir.addFromReader(reader);
+                } catch (Exception e) {
+                    throw new VirtualDirectoryException("Failed to read virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                }
+            }
+        }
+        /* If that worked, make the new config active */
+        root = vdir;
+    }
+
+    /* Get the current virtual directory root */
+    public VirtualDirectory getRoot() {
+        return root;
+    }
+}

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ExternalConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/ExternalConfigManager.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.util.zip.GZIPInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.concurrent.locks.ReentrantLock;
 
 import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
 import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
@@ -14,9 +15,11 @@ public class ExternalConfigManager extends ConfigManager {
 
     private String[] directory_configs = null;
     private volatile VirtualDirectory root = null;
+    private final ReentrantLock lock = new ReentrantLock();
 
     /* Initialize the configuration. This implementation reads
-     * external files (i.e. not in the .war) */
+     * external files (i.e. not in the .war) and can reload the config
+     * without reloading the whole web app */
     public ExternalConfigManager(String[] directory_configs) throws VirtualDirectoryException {
         super();
         this.directory_configs = directory_configs;
@@ -24,26 +27,43 @@ public class ExternalConfigManager extends ConfigManager {
     }
 
     private void load() throws VirtualDirectoryException {
-        VirtualDirectory vdir = new VirtualDirectory();
-        for(String directory_config : directory_configs) {
-            if(directory_config.endsWith(".gz")) {
-                /* Assume config file is gzipped if it has a .gz extension */
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(directory_config)))))) {
-                    vdir.addFromReader(reader);
-                } catch (Exception e) {
-                    throw new VirtualDirectoryException("Failed to read gzipped virtual directory configuration: " + directory_config + " : " + e.getMessage());
-                }
-            } else {
-                /* Uncompressed config file */
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(directory_config))))) {
-                    vdir.addFromReader(reader);
-                } catch (Exception e) {
-                    throw new VirtualDirectoryException("Failed to read virtual directory configuration: " + directory_config + " : " + e.getMessage());
+
+        /* Fail if loading is already in progress */
+        if (!lock.tryLock()) {
+            throw new VirtualDirectoryException("Reload is already in progress");
+        }
+
+        /* Try to reload the config */
+        try {
+            VirtualDirectory vdir = new VirtualDirectory();
+            for(String directory_config : directory_configs) {
+                if(directory_config.endsWith(".gz")) {
+                    /* Assume config file is gzipped if it has a .gz extension */
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(directory_config)))))) {
+                        vdir.addFromReader(reader);
+                    } catch (Exception e) {
+                        throw new VirtualDirectoryException("Failed to read gzipped virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                    }
+                } else {
+                    /* Uncompressed config file */
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(directory_config))))) {
+                        vdir.addFromReader(reader);
+                    } catch (Exception e) {
+                        throw new VirtualDirectoryException("Failed to read virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                    }
                 }
             }
+            /* If that worked, make the new config active */
+            root = vdir;
+        } finally {
+            /* Whatever happened, always release the lock */
+            lock.unlock();
         }
-        /* If that worked, make the new config active */
-        root = vdir;
+    }
+
+    /* Reload the configuration */
+    public void reload() throws VirtualDirectoryException {
+        load();
     }
 
     /* Get the current virtual directory root */

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/HDFStreamContextListener.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/HDFStreamContextListener.java
@@ -5,13 +5,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
 import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.zip.GZIPInputStream;
 
 import uk.ac.dur.cosma.libhdfstream.*;
 
@@ -28,15 +21,6 @@ public class HDFStreamContextListener implements ServletContextListener{
             result[i] = fields[i].trim();
         }
         return result;
-    }
-
-    // Open a file if external_config!=0, or a resource in the war file otherwise
-    protected InputStream getResource(ServletContext context, String name, int external_config) throws IOException {
-        if(external_config != 0) {
-            return new FileInputStream(new File(name));
-        } else {
-            return context.getResourceAsStream(name);
-        }
     }
 
     // During unit tests this is overriden to use the hdfstream_reader executable from the build directory.
@@ -76,35 +60,21 @@ public class HDFStreamContextListener implements ServletContextListener{
 	context.setAttribute("buffer_size", buffer_size);
 
         /*
-          Read virtual directory configuration
-
-          Note that we have to be sure to close the config file immediately
-          after reading it to avoid problems when reloading the web app, so
-          we use a try() block to ensure it gets auto-closed. This prevents
-          "WEB-INF could not be completely deleted" errors in catalina.out.
-
-          directory_configs may contain multiple filenames separated by
-          semicolons, in which case we read all of the specified files.
+          Read virtual directory configuration. directory_configs may
+          contain multiple filenames separated by semicolons, in which
+          case we read all of the specified files.
         */
-        VirtualDirectory vdir = new VirtualDirectory();
-        for(String directory_config : directory_configs) {
-            if(directory_config.endsWith(".gz")) {
-                /* Assume config file is gzipped if it has a .gz extension */
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(getResource(context, directory_config, external_config))))) {
-                    vdir.addFromReader(reader);
-                } catch (Exception e) {
-                    throw new RuntimeException("Failed to read gzipped virtual directory configuration: " + directory_config + " : " + e.getMessage());
-                }
+        ConfigManager config;
+        try {
+            if(external_config != 0) {
+                config = new ExternalConfigManager(directory_configs);
             } else {
-                /* Uncompressed config file */
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(getResource(context, directory_config, external_config)))) {
-                    vdir.addFromReader(reader);
-                } catch (Exception e) {
-                    throw new RuntimeException("Failed to read virtual directory configuration: " + directory_config + " : " + e.getMessage());
-                }
+                config = new InternalConfigManager(context, directory_configs);
             }
+        } catch (VirtualDirectoryException e) {
+            config = null;
         }
-	context.setAttribute("virtual_directory", vdir);
+        context.setAttribute("config", config);
 
         /* Set up object to limit concurrent requests per user */
         ConcurrentRequestCount crc = new ConcurrentRequestCount(max_requests_per_user);

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/HDFStreamServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/HDFStreamServlet.java
@@ -90,7 +90,7 @@ public class HDFStreamServlet extends HttpServlet implements Servlet {
     {
         // Get the virtual directory structure
         ServletContext context = getServletContext();
-        VirtualDirectory virtual_directory = (VirtualDirectory) context.getAttribute("virtual_directory");
+        VirtualDirectory virtual_directory = ((ConfigManager) context.getAttribute("config")).getRoot();
 
         // Expression which returns true if user belongs to a role:
         // This determines which directories we can see.
@@ -192,7 +192,7 @@ public class HDFStreamServlet extends HttpServlet implements Servlet {
     {
         // Get the virtual directory structure
         ServletContext context = getServletContext();
-        VirtualDirectory virtual_directory = (VirtualDirectory) context.getAttribute("virtual_directory");
+        VirtualDirectory virtual_directory = ((ConfigManager) context.getAttribute("config")).getRoot();
 
         // Expression which returns true if user belongs to a role:
         // This determines which directories we can see.

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/InternalConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/InternalConfigManager.java
@@ -1,0 +1,49 @@
+package uk.ac.dur.cosma.hdfstream;
+
+import javax.servlet.ServletContext;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.util.zip.GZIPInputStream;
+
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
+
+
+public class InternalConfigManager extends ConfigManager {
+
+    private VirtualDirectory root = null;
+
+    /*
+      Initialize the configuration. This implementation assumes the
+      config is in the .war file and cannot be updated while the
+      service is running.
+    */
+    public InternalConfigManager(ServletContext context, String[] directory_configs) throws VirtualDirectoryException {
+        super();
+        VirtualDirectory vdir = new VirtualDirectory();
+        for(String directory_config : directory_configs) {
+            if(directory_config.endsWith(".gz")) {
+                /* Assume config file is gzipped if it has a .gz extension */
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(context.getResourceAsStream(directory_config))))) {
+                    vdir.addFromReader(reader);
+                } catch (Exception e) {
+                    throw new VirtualDirectoryException("Failed to read gzipped virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                }
+            } else {
+                /* Uncompressed config file */
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(context.getResourceAsStream(directory_config)))) {
+                    vdir.addFromReader(reader);
+                } catch (Exception e) {
+                    throw new VirtualDirectoryException("Failed to read virtual directory configuration: " + directory_config + " : " + e.getMessage());
+                }
+            }
+        }
+        /* If that worked, make the new config active */
+        root = vdir;
+    }
+
+    /* Get the current virtual directory root */
+    public VirtualDirectory getRoot() {
+        return root;
+    }
+}

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/InternalConfigManager.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/InternalConfigManager.java
@@ -42,6 +42,11 @@ public class InternalConfigManager extends ConfigManager {
         root = vdir;
     }
 
+    /* Reloading is not possible */
+    public void reload() throws VirtualDirectoryException {
+        throw new VirtualDirectoryException("Reloading is not supported!");
+    }
+
     /* Get the current virtual directory root */
     public VirtualDirectory getRoot() {
         return root;

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import uk.ac.dur.cosma.virtual_directory.VirtualDirectory;
+import uk.ac.dur.cosma.virtual_directory.VirtualDirectoryException;
 import uk.ac.dur.cosma.libhdfstream.*;
 
 public class StatusServlet extends HttpServlet implements Servlet {
@@ -33,8 +34,29 @@ public class StatusServlet extends HttpServlet implements Servlet {
     protected void doHeadOrGet(HttpServletRequest request, HttpServletResponse response, boolean is_get)
 	throws ServletException, IOException
     {
+        ServletContext context = getServletContext();
+        String message = null;
+
+        // Check we have a virtual directory config
+        ConfigManager config = (ConfigManager) context.getAttribute("config");
+        if(config == null) {
+            message = "Failed to read virtual directory configuration";
+        } else {
+            message = "Server started";
+        }
+
+        // Check for the reload flag
+        String reload = request.getParameter("reload");
+        if((config != null) && (reload != null) && reload.equals("1")) {
+            try {
+                config.reload();
+                message = "Server configuration reloaded";
+            } catch (VirtualDirectoryException e) {
+                message = "Reload failed: "+e.getMessage();
+            }
+        }
+
         // Return an internal server error if hdfstream didn't start
-	ServletContext context = getServletContext();
 	HDFStream hs = (HDFStream) context.getAttribute("hdfstream");
         if(hs==null) {
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Hdfstream library initialization failed");
@@ -54,10 +76,13 @@ public class StatusServlet extends HttpServlet implements Servlet {
         request.setAttribute("cache_info", cache_info);
 
         // Get total data size as a string
-        VirtualDirectory root = ((ConfigManager) context.getAttribute("config")).getRoot();
+        VirtualDirectory root = config.getRoot();
         long size = root.getTotalSize((in) -> true);
         String total_size = VirtualDirectory.formatSize(size);
         request.setAttribute("total_size", total_size);
+
+        // Store any status message
+        request.setAttribute("status_message", message);
 
         // Forward this request to the directory status page
         RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/status.jsp");

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
@@ -36,6 +36,7 @@ public class StatusServlet extends HttpServlet implements Servlet {
     {
         ServletContext context = getServletContext();
         String message = null;
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/status.jsp");
 
         // Don't allow remote access to this page for anyone, just in
         // case we forget the remote address filter in web.xml!
@@ -53,6 +54,13 @@ public class StatusServlet extends HttpServlet implements Servlet {
             message = "Server started";
         }
 
+        // Return an internal server error if hdfstream didn't start
+	HDFStream hs = (HDFStream) context.getAttribute("hdfstream");
+        if(hs==null) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Hdfstream library initialization failed");
+            return;
+        }
+
         // Check for the reload flag
         String reload = request.getParameter("reload");
         if((config != null) && (reload != null) && reload.equals("1")) {
@@ -62,13 +70,10 @@ public class StatusServlet extends HttpServlet implements Servlet {
             } catch (VirtualDirectoryException e) {
                 message = "Reload failed: "+e.getMessage();
             }
-        }
-
-        // Return an internal server error if hdfstream didn't start
-	HDFStream hs = (HDFStream) context.getAttribute("hdfstream");
-        if(hs==null) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Hdfstream library initialization failed");
-            return;
+            if(dispatcher == null) {
+                response.setStatus(200);
+                return;
+            }
         }
 
         // Determine number of processes
@@ -93,7 +98,6 @@ public class StatusServlet extends HttpServlet implements Servlet {
         request.setAttribute("status_message", message);
 
         // Forward this request to the directory status page
-        RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/status.jsp");
         dispatcher.forward(request, response);
     }
 }

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
@@ -37,6 +37,14 @@ public class StatusServlet extends HttpServlet implements Servlet {
         ServletContext context = getServletContext();
         String message = null;
 
+        // Don't allow remote access to this page for anyone, just in
+        // case we forget the remote address filter in web.xml!
+        String ip = request.getRemoteAddr();
+        if ((!ip.equals("127.0.0.1")) && (!ip.equals("0:0:0:0:0:0:0:1"))) {
+            response.sendError(404);
+            return;
+        }
+
         // Check we have a virtual directory config
         ConfigManager config = (ConfigManager) context.getAttribute("config");
         if(config == null) {

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
@@ -54,7 +54,7 @@ public class StatusServlet extends HttpServlet implements Servlet {
         request.setAttribute("cache_info", cache_info);
 
         // Get total data size as a string
-        VirtualDirectory root = (VirtualDirectory) context.getAttribute("virtual_directory");
+        VirtualDirectory root = ((ConfigManager) context.getAttribute("config")).getRoot();
         long size = root.getTotalSize((in) -> true);
         String total_size = VirtualDirectory.formatSize(size);
         request.setAttribute("total_size", total_size);

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/StatusServlet.java
@@ -51,7 +51,7 @@ public class StatusServlet extends HttpServlet implements Servlet {
         if(config == null) {
             message = "Failed to read virtual directory configuration";
         } else {
-            message = "Server started";
+            message = "Server started, connected from " + ip;
         }
 
         // Return an internal server error if hdfstream didn't start

--- a/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/TarFileServlet.java
+++ b/webapp/src/main/java/uk/ac/dur/cosma/hdfstream/TarFileServlet.java
@@ -98,7 +98,7 @@ public class TarFileServlet extends HttpServlet implements Servlet {
     {
         // Get the directory structure
         ServletContext context = getServletContext();
-	VirtualDirectory virtual_directory = (VirtualDirectory) context.getAttribute("virtual_directory");
+        VirtualDirectory virtual_directory = ((ConfigManager) context.getAttribute("config")).getRoot();
 
         // Expression which returns true if user belongs to a role:
         // This determines which directories we can see.

--- a/webapp/src/main/webapp/WEB-INF/status.jsp
+++ b/webapp/src/main/webapp/WEB-INF/status.jsp
@@ -15,6 +15,9 @@
       <fmt:formatDate value="${now}" type="date" />, <fmt:formatDate value="${now}" type="time" />
     </p>
     <p>
+      <c:out value="${status_message}"/>
+    </p>
+    <p>
       Total configured data: <c:out value="${total_size}"/>
     </p>
     <h3>Process pool</h3>

--- a/webapp/src/test/java/BasicUnitTest.java
+++ b/webapp/src/test/java/BasicUnitTest.java
@@ -15,6 +15,9 @@ public abstract class BasicUnitTest {
     protected static UnitTestServer server;
     protected static UnitTestClient client;
 
+    // Default config file to use
+    protected static String default_config = "../../data/tests/basic/config.csv";
+
     public static void startServer(String config) throws Exception {
 
         // Locate file with the virtual directory config for the test data
@@ -31,7 +34,7 @@ public abstract class BasicUnitTest {
 
     @BeforeAll
     public static void setUp() throws Exception {
-        startServer("../../data/tests/basic/config.csv");
+        startServer(default_config);
     }
 
     @AfterAll

--- a/webapp/src/test/java/TestReload.java
+++ b/webapp/src/test/java/TestReload.java
@@ -1,0 +1,31 @@
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+  Test requesting a HDF5 group from the server.
+*/
+public class TestReload extends BasicUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testReloading(boolean post) throws Exception {
+
+        // Request a dataset
+        {
+            HDF5Object dataset = client.requestObject("/tests/basic/test_data.hdf5", "/data", null, null, 200, post);
+            assertNotEquals(null, dataset);
+        }
+
+        // Reload the server config
+        assertEquals(true, client.requestReload());
+
+        // Try the dataset request again
+        {
+            HDF5Object dataset = client.requestObject("/tests/basic/test_data.hdf5", "/data", null, null, 200, post);
+            assertNotEquals(null, dataset);
+        }
+    }
+}

--- a/webapp/src/test/java/UnitTestClient.java
+++ b/webapp/src/test/java/UnitTestClient.java
@@ -241,4 +241,18 @@ public class UnitTestClient {
         }
         return data;
     }
+
+    public boolean requestReload() throws Exception {
+
+        // Construct URI with the path
+        URIBuilder builder = new URIBuilder(baseURL+"/status");
+        builder.addParameter("reload", "1");
+        URI uri = builder.build();
+        HttpUriRequest request = new HttpGet(uri);
+
+        // Send the request and return true if it worked
+        try (CloseableHttpResponse response = client.execute(request)) {
+            return (response.getStatusLine().getStatusCode() == 200);
+        }
+    }
 }

--- a/webapp/src/test/java/UnitTestServer.java
+++ b/webapp/src/test/java/UnitTestServer.java
@@ -90,6 +90,8 @@ public class UnitTestServer {
         context.addServletMappingDecoded("/msgpack/*", "HDFStreamServlet");
 	Tomcat.addServlet(context, "TarFileServlet", new TarFileServlet());
         context.addServletMappingDecoded("/download/*", "TarFileServlet");
+	Tomcat.addServlet(context, "StatusServlet", new StatusServlet());
+        context.addServletMappingDecoded("/status", "StatusServlet");
 
         // Set login config, if users were specified
         if(userPasswords != null) {


### PR DESCRIPTION
This adds the ability to reload the virtual directory config files(s) without reloading the whole application, which would interrupt any requests which are being processed. Requests will continue to use the configuration that was active at the moment the request was received.